### PR TITLE
Optimize LLM usage and statistics

### DIFF
--- a/src/main/java/controller/Statistic.java
+++ b/src/main/java/controller/Statistic.java
@@ -36,10 +36,8 @@ public class Statistic {
     private int settledRounds = 0;   // số ván đã settle (đã có actual)
     private int correctOnBets = 0;   // số đúng trong các ván CÓ đặt (bỏ qua SKIP)
 
-    // confusion
-    private int pTAI_aT = 0, pTAI_aX = 0;
-    private int pXIU_aX = 0, pXIU_aT = 0;
-    private int pSKIP_aT = 0, pSKIP_aX = 0;
+    // confusion[pred][actual]
+    private final int[][] confusion = new int[Pred.values().length][Actual.values().length];
 
     private final DateTimeFormatter tsFmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final Pattern PICK_RE = Pattern.compile("\"pick\"\\s*:\\s*\"\\s*(TAI|XIU|SKIP)\\s*\"", Pattern.CASE_INSENSITIVE);
@@ -100,29 +98,10 @@ public class Statistic {
 
     private void settleAndReport(String history, Pred pred, Actual actual) {
         // confusion + correct
-        switch (pred) {
-            case TAI -> {
-                if (actual == Actual.T) {
-                    pTAI_aT++;
-                    correctOnBets++;
-                } else {
-                    pTAI_aX++;
-                }
-            }
-            case XIU -> {
-                if (actual == Actual.X) {
-                    pXIU_aX++;
-                    correctOnBets++;
-                } else {
-                    pXIU_aT++;
-                }
-            }
-            case SKIP -> {
-                if (actual == Actual.T) {
-                    pSKIP_aT++;
-                } else {
-                    pSKIP_aX++;
-                }
+        confusion[pred.ordinal()][actual.ordinal()]++;
+        if (pred != Pred.SKIP) {
+            if ((pred == Pred.TAI && actual == Actual.T) || (pred == Pred.XIU && actual == Actual.X)) {
+                correctOnBets++;
             }
         }
 
@@ -141,7 +120,12 @@ public class Statistic {
 
         if (settledRounds % 10 == 0) {
             System.out.printf("Confusion: TAI->T:%d TAI->X:%d | XIU->X:%d XIU->T:%d | SKIP->T:%d SKIP->X:%d%n",
-                    pTAI_aT, pTAI_aX, pXIU_aX, pXIU_aT, pSKIP_aT, pSKIP_aX);
+                    confusion[Pred.TAI.ordinal()][Actual.T.ordinal()],
+                    confusion[Pred.TAI.ordinal()][Actual.X.ordinal()],
+                    confusion[Pred.XIU.ordinal()][Actual.X.ordinal()],
+                    confusion[Pred.XIU.ordinal()][Actual.T.ordinal()],
+                    confusion[Pred.SKIP.ordinal()][Actual.T.ordinal()],
+                    confusion[Pred.SKIP.ordinal()][Actual.X.ordinal()]);
         }
     }
 

--- a/src/main/java/model/LLM.java
+++ b/src/main/java/model/LLM.java
@@ -2,23 +2,26 @@ package model;
 
 import com.google.genai.Client;
 import com.google.genai.types.GenerateContentResponse;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class LLM {
-    Client client = Client.builder().apiKey("AIzaSyCSeJkWCGwwX-BABEMS7yYpkVSZMBqhJ-U").build();
-    
-    
-    String context = """
+    private static final Client CLIENT = Client.builder()
+            .apiKey(System.getenv().getOrDefault("GENAI_API_KEY", "AIzaSyCSeJkWCGwwX-BABEMS7yYpkVSZMBqhJ-U"))
+            .build();
+
+    private static final String CONTEXT = """
                      ROLE
                      You are a cold, rational analyst for a dice-based Tài/Xỉu game that may be manipulated.
                      Input will always be exactly 13 most recent results, with "T" meaning Tài and "X" meaning Xỉu.
                      Your only task is to output one of {TAI, XIU, SKIP} based strictly on pattern analysis.
-                     
+
                      INPUT FORMAT
                      The user will provide a JSON object:
                      {
                        "history": "string of 13 characters over {T,X}, oldest to newest, newest is the last character"
                      }
-                     
+
                      ANALYSIS PROCEDURE
                      1. Identify the last run: the symbol of the last streak and its length.
                      2. Identify the previous run: the symbol and length of the streak immediately before the last run.
@@ -27,22 +30,22 @@ public class LLM {
                      5. Determine if an oscillation pattern exists: this is true when both the last run and the previous run are length 4 or greater and have opposite symbols.
                      6. Determine dominance: the higher of the two proportions.
                      7. Determine imbalance: the absolute difference between p_T and 0.5.
-                     
+
                      SCORING RULES
                      Maintain three scores: anti-run, follow, and skip. Apply the following adjustments:
-                     
+
                      - If an oscillation pattern is detected, increase anti-run score by 2.
                      - If the last run length is 5 or more and the previous run length is 2 or less, increase anti-run score by 1.
                      - If the last run length is 5 or more and not oscillation, increase skip score by 1.
                      - If the last run length is between 1 and 3 and the dominant side has proportion at least 0.6, increase follow score by 1.
                      - If alternation rate is greater than or equal to 0.7, increase skip score by 2.
                      - If dominance is at least 0.65, increase follow score by 1.
-                     
+
                      DECISION RULES
                      - If anti-run score is strictly higher than both follow and skip, then pick the opposite of the last run symbol.
                      - Else if follow score is strictly higher than both anti-run and skip, then pick the last run symbol or the majority side.
                      - Else if skip score is highest, or there is a tie between categories, output SKIP.
-                     
+
                      OUTPUT FORMAT
                      Always respond with strict JSON:
                      {
@@ -58,17 +61,23 @@ public class LLM {
                        },
                        "rationale": "no more than 20 words, concise, mechanical"
                      }
-                     
+
                      STYLE
                      - Cold, technical, and emotionless.
                      - Do not mention luck, feelings, money, or legality.
                      - When no clear signal exists, prefer SKIP.
-                     
+
                      This is my json: %s.
                      """;
+
+    private final Map<String, String> cache = new ConcurrentHashMap<>();
+
     public String getAnswer(String inputJson) {
-        String content = String.format(context, inputJson);
-        GenerateContentResponse respone = client.models.generateContent("gemini-2.5-flash", content, null);
-        return respone.text();
+        return cache.computeIfAbsent(inputJson, key -> {
+            String content = String.format(CONTEXT, key);
+            GenerateContentResponse response = CLIENT.models.generateContent("gemini-2.5-flash", content, null);
+            return response.text();
+        });
     }
 }
+


### PR DESCRIPTION
## Summary
- cache LLM responses and allow API key from environment
- streamline confusion matrix handling in statistics module

## Testing
- ❌ `mvn -q -DskipTests compile` (failed: Network is unreachable for Maven dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68a899a5aa8c8328bb636050415be774