### PR TITLE
Add configurable round limit and summary statistics

### DIFF
--- a/src/main/java/view/Run.java
+++ b/src/main/java/view/Run.java
@@ -4,7 +4,15 @@ import controller.Statistic;
 
 public class Run {
     public static void main(String[] args) {
-        Statistic st = new Statistic();
+        int rounds = 10;
+        if (args.length > 0) {
+            try {
+                rounds = Integer.parseInt(args[0]);
+            } catch (NumberFormatException e) {
+                System.err.println("Invalid round count, using default 10");
+            }
+        }
+        Statistic st = new Statistic(rounds);
         st.run();
     }
 }


### PR DESCRIPTION
## Summary
- Add round limit configuration with default of 10 rounds and stop program once limit reached
- Print streamlined per-round outputs and final summary table of key statistics
- Allow users to specify round count via command line argument

## Testing
- `mvn -q test` *(fails: Plugin resolution network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b8fea1f8832893adc97f2c3f660f