### PR TITLE
Fix misplaced brace in Statistic run method

### DIFF
--- a/src/main/java/controller/Statistic.java
+++ b/src/main/java/controller/Statistic.java
@@ -139,7 +139,6 @@ public class Statistic {
             // Không đổi round → heartbeat / stall warn
             heartbeat();
         }
-        }
         printSummary();
     }
 


### PR DESCRIPTION
## Summary
- Fix extra closing brace in `Statistic.run` so `printSummary` executes after the polling loop

## Testing
- `javac $(find src/main/java -name '*.java')`
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8be9dc4148328b3050ae669bd9dd9