### PR TITLE
Fix Statistic.java merge conflict markers

### DIFF
--- a/src/main/java/view/Statistic.java
+++ b/src/main/java/view/Statistic.java
@@ -140,10 +140,6 @@ public class Statistic {
             // Không đổi round → heartbeat / stall warn
             heartbeat();
         }
-<<<<<<< HEAD:src/main/java/view/Statistic.java
-        
-=======
->>>>>>> 0ccb6f8087256935d3528975dfa07bfe9f263354:src/main/java/controller/Statistic.java
         printSummary();
     }
 


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers in `Statistic.run`
- always print summary after scanning ends

## Testing
- `mvn -q test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c9ac28008328ab415205b4681f96